### PR TITLE
fix(typescript): resolve types when using 'bundler' as 'moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": {
       "require": "./dist/PointerTracker.js",
+      "types": "./dist/index.d.ts",
       "import": "./dist/PointerTracker.mjs"
     },
     "./dist/*": "./dist/*",


### PR DESCRIPTION
I am using a Vite setup which has `"moduleResolution": "bundler",` in its `tsconfig.json`. I am not sure if it is because of that but TypeScript can't get the types resolved. Adding `"types"` to the custom export does the trick.